### PR TITLE
Added Stash Metadata Scraping via GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The apikey is optional and can be left out if you dont have authentication enabl
 |sessioncookie|||sessioncookie which should be used|
 |[searchpathoverride](#searchpathoverride)|||override the relative path for the search in stash
 |[when](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#post-processing-options)|||when postprocessor is called
+|[legacy]|false|---|use legacy postprocessor|
 
 #### apikey & sessioncookie
 if api key and **sessioncookie** are provided api key is preferred.
@@ -51,6 +52,9 @@ by default the Processor expects the same path for the media in stash as it is d
 #### when
 You might need to change `after_video` to `playlist` if you are downloading a playlist.
 I haven't tested this yet.
+
+#### legacy
+The legacy version of the postprocessor uses data directly from yt-dlp. The new version uses Stash's GraphQL to scrape the URL after import. (Note: you must install any [CommunityScrapers](https://github.com/stashapp/CommunityScrapers) you plan to use within Stash first for this to work properly)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The apikey is optional and can be left out if you dont have authentication enabl
 |sessioncookie|||sessioncookie which should be used|
 |[searchpathoverride](#searchpathoverride)|||override the relative path for the search in stash
 |[when](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#post-processing-options)|||when postprocessor is called
-|[legacy](#legacy)|false|---|use legacy postprocessor|
+|[scrapemethod](#scrapemethod)|yt_dlp|---|postprocessor scraping method, either yt_dlp or stash|
 
 #### apikey & sessioncookie
 if api key and **sessioncookie** are provided api key is preferred.
@@ -53,8 +53,8 @@ by default the Processor expects the same path for the media in stash as it is d
 You might need to change `after_video` to `playlist` if you are downloading a playlist.
 I haven't tested this yet.
 
-#### legacy
-The legacy version of the postprocessor uses data directly from yt-dlp. The new version uses Stash's GraphQL to scrape the URL after import. (Note: you must install any [CommunityScrapers](https://github.com/stashapp/CommunityScrapers) you plan to use within Stash first for this to work properly)
+#### scrapemethod
+With `yt_dlp` the postprocessor uses data directly from yt-dlp. Using `stash` triggers Stash's GraphQL to scrape the URL after import. (Note: you must install any [CommunityScrapers](https://github.com/stashapp/CommunityScrapers) you plan to use within Stash first for this to work properly)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The apikey is optional and can be left out if you dont have authentication enabl
 |sessioncookie|||sessioncookie which should be used|
 |[searchpathoverride](#searchpathoverride)|||override the relative path for the search in stash
 |[when](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#post-processing-options)|||when postprocessor is called
-|[legacy]|false|---|use legacy postprocessor|
+|[legacy](#legacy)|false|---|use legacy postprocessor|
 
 #### apikey & sessioncookie
 if api key and **sessioncookie** are provided api key is preferred.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt-dlp-stash
-version = 1.2.0
+version = 2.0.0
 
 [options]
 packages = find_namespace:

--- a/yt_dlp_plugins/postprocessor/stash.py
+++ b/yt_dlp_plugins/postprocessor/stash.py
@@ -11,12 +11,13 @@ from pathlib import Path
 
 
 class StashPP(PostProcessor):
-    def __init__(self, downloader=None, scheme: str='http', host: str='localhost', port: int=9999, apikey: str='', sessioncookie: str='', searchpathoverride: str='', **kwargs):
+    def __init__(self, downloader=None, scheme: str='http', host: str='localhost', port: int=9999, apikey: str='', sessioncookie: str='', searchpathoverride: str='', legacy: str='false', **kwargs):
         # ⚠ Only kwargs can be passed from the CLI, and all argument values will be string
         # Also, "downloader", "when" and "key" are reserved names
         super().__init__(downloader)
         self.tag = None
         self._kwargs = kwargs
+        self.legacy = legacy.lower() == 'true'
         stash_args = {
                 "Scheme": scheme,
                 "Host": host,
@@ -30,8 +31,14 @@ class StashPP(PostProcessor):
         self.stash = StashInterface(stash_args)
         self.searchpathoverride = searchpathoverride
 
-    # ℹ️ See docstring of yt_dlp.postprocessor.common.PostProcessor.run
     def run(self, info):
+        if self.legacy:
+            return self.run_legacy(info)
+        # Updated logic uses Stash GraphQL API to update the scene
+        return self.run_updated(info)
+
+    # ℹ️ See docstring of yt_dlp.postprocessor.common.PostProcessor.run
+    def run_legacy(self, info):
         if self.searchpathoverride != '':
             filepath = (self.searchpathoverride + info['requested_downloads'][0]['filename'][1:]).replace("//","/")
             dirpath = "/".join(filepath.split("/")[0:-1])
@@ -73,3 +80,213 @@ class StashPP(PostProcessor):
         self.stash.update_scene(update_scene)
         self.to_screen("Updatet Scene")
         return [], info
+    
+    def run_updated(self, info):
+        try:
+            # Step 1: Determine the file path and directory
+            if self.searchpathoverride != '':
+                # Get the full relative path of the downloaded file
+                full_download_path = Path(info['requested_downloads'][0]['filepath'])
+                # Determine the correct root directory for relative path calculation
+                download_root = Path(info['requested_downloads'][0]['__finaldir']).parent.parent
+                relative_path = full_download_path.relative_to(download_root)
+
+                # Create the new filepath by combining searchpathoverride with the relative path
+                filepath = Path(self.searchpathoverride) / relative_path
+            else:
+                filepath = Path(info['requested_downloads'][0]['filepath'])
+
+            # Convert the path to a string with forward slashes for compatibility
+            filepath = str(filepath).replace("\\", "/")
+            dirpath = str(Path(filepath).parent).replace("\\", "/")
+
+            # Debugging: Print the file path and directory path
+            self.to_screen(f"[Debug] Full download path: {full_download_path}")
+            self.to_screen(f"[Debug] Download root: {download_root}")
+            self.to_screen(f"[Debug] Relative path: {relative_path}")
+            self.to_screen(f"[Debug] Filepath for metadata scan: {filepath}")
+            self.to_screen(f"[Debug] Directory for metadata scan: {dirpath}")
+
+            # Step 3: Metadata scan for the input file
+            self.to_screen("[Debug] Initiating metadata scan on path: " + dirpath)
+            stash_meta_job = self.stash.metadata_scan(paths=dirpath, flags={
+                "scanGenerateCovers": False,
+                "scanGeneratePreviews": False,
+                "scanGenerateImagePreviews": False,
+                "scanGenerateSprites": False,
+                "scanGeneratePhashes": False,
+                "scanGenerateThumbnails": False,
+                "scanGenerateClipPreviews": False
+            })
+            self.to_screen(f"[Debug] Metadata scan job ID: {stash_meta_job}")
+
+            # Step 4: Wait until metadata scan is complete
+            while True:
+                job_status = self.stash.find_job(stash_meta_job)
+                self.to_screen(f"[Debug] Metadata scan job status: {job_status}")
+                if job_status["status"] == "FINISHED":
+                    break
+                elif job_status["status"] == "FAILED":
+                    self.to_screen("[Error] Metadata scan job failed.")
+                    return [], info
+                sleep(0.5)
+
+            # Step 5: Find the newly created scene
+            self.to_screen(f"[Debug] Looking for scene with path: {filepath}")
+            scene = self.stash.find_scenes({"path": {"modifier": "EQUALS", "value": filepath}})
+            self.to_screen(f"[Debug] Scene search result: {scene}")
+            if not scene or len(scene) == 0:
+                self.to_screen("[Error] No scene found after metadata scan. Please verify the path and metadata settings.")
+                return [], info
+
+            scene_id = scene[0]["id"]
+            self.to_screen(f"[Debug] Found scene with id: {scene_id}")
+
+            # Step 6: Scrape metadata from URL
+            if "webpage_url" not in info:
+                self.to_screen("[Error] No URL found for scraping")
+                return [], info
+
+            self.to_screen(f"[Debug] Scraping metadata from URL: {info['webpage_url']}")
+            scene_data = self.scrape_scene_by_url(info['webpage_url'])
+
+            if not scene_data:
+                self.to_screen("[Error] Error or no data found during scraping.")
+                return [], info
+
+            # Step 7: Update the scene data using the scraped information
+            update_scene = {
+                "id": scene_id,
+                "url": info.get("webpage_url"),
+            }
+
+            if scene_data.get("title"):
+                update_scene["title"] = scene_data["title"]
+            elif info.get("title"):
+                update_scene["title"] = info["title"]
+
+            if scene_data.get("details"):
+                update_scene["details"] = scene_data["details"]
+            elif info.get("description"):
+                update_scene["details"] = info["description"]
+
+            if scene_data.get("date"):
+                update_scene["date"] = scene_data["date"]
+
+            if scene_data.get("image"):
+                update_scene["cover_image"] = scene_data["image"]
+            elif info.get("thumbnail"):
+                update_scene["cover_image"] = info["thumbnail"]
+
+            if scene_data.get("tags"):
+                update_scene["tags"] = [{"name": tag["name"]} for tag in scene_data["tags"]]
+
+            # Step to handle performers
+            if scene_data.get("performers"):
+                performer_ids = []
+                for performer in scene_data["performers"]:
+                    performer_name = performer["name"]
+                    performer_url = performer.get("url")
+                    
+                    # Search for existing performer
+                    existing_performer = self.stash.find_performers({"name": {"modifier": "EQUALS", "value": performer_name}})
+                    
+                    if existing_performer and len(existing_performer) > 0:
+                        performer_ids.append(existing_performer[0]["id"])
+                    else:
+                        # Create the performer if they don't exist
+                        new_performer = {"name": performer_name}
+                        if performer_url:
+                            new_performer["url"] = performer_url
+                        
+                        created_performer = self.stash.create_performer(new_performer)
+                        performer_ids.append(created_performer["id"])
+                
+                # Add performer IDs to the update payload
+                update_scene["performer_ids"] = performer_ids
+
+            if scene_data.get("studio"):
+                studio_name = scene_data["studio"]["name"]
+                existing_studio = self.stash.find_studios({"name": {"modifier": "EQUALS", "value": studio_name}})
+                
+                if not existing_studio:
+                    existing_studio = self.stash.find_studios({"aliases": {"modifier": "EQUALS", "value": studio_name}})
+                
+                if existing_studio and len(existing_studio) > 0:
+                    update_scene["studio_id"] = existing_studio[0]["id"]
+                    self.to_screen(f"[Debug] using existing studio {existing_studio}")
+                else:
+                    # Create the studio if it doesn't exist
+                    self.to_screen("[Debug] creating new studio")
+                    new_studio = {
+                        "name": studio_name,
+                        "url": scene_data["studio"]["url"] if scene_data["studio"].get("url") else None
+                    }
+                    created_studio = self.stash.create_studio(new_studio)
+                    update_scene["studio_id"] = created_studio["id"]
+
+            self.to_screen(f"[Debug] Scene update payload: {update_scene}")
+
+            try:
+                self.stash.update_scene(update_scene)
+                self.to_screen("[Debug] Scene updated with scraped metadata.")
+            except Exception as e:
+                self.to_screen(f"[Error] Error updating scene metadata: {str(e)}")
+
+        except Exception as e:
+            self.to_screen(f"[Error] Unexpected error during processing: {str(e)}")
+
+        return [], info
+    
+    def scrape_scene_by_url(self, url):
+        query = """
+        query scrapeSceneByURL($url: String!) {
+            scrapeSceneURL(url: $url) {
+                title
+                date
+                details
+                tags {
+                    name
+                }
+                performers {
+                    name
+                    url
+                }
+                studio {
+                    name
+                    url
+                }
+            }
+        }
+        """
+        variables = {
+            "url": url
+        }
+        try:
+            self.to_screen(f"[Debug] Sending GraphQL scrapeSceneByURL query for URL: {url}")
+            response = self.stash.call_GQL(query, variables)
+            self.to_screen(f"[Debug] Full GraphQL response: {response}")
+
+            # Adjust the response check to accommodate both formats
+            scrape_scene_data = None
+            if 'data' in response and isinstance(response['data'], dict):
+                scrape_scene_data = response['data'].get('scrapeSceneURL')
+            elif 'scrapeSceneURL' in response:
+                scrape_scene_data = response['scrapeSceneURL']
+
+            if scrape_scene_data is None:
+                self.to_screen("[Error] 'scrapeSceneURL' field missing or is None in GraphQL response.")
+                self.to_screen(f"[Debug] Response structure: {response}")
+                return None
+
+            # Add detailed debug messages to understand what we received
+            if scrape_scene_data:
+                self.to_screen(f"[Debug] Scraped scene data: {scrape_scene_data}")
+                return scrape_scene_data
+            else:
+                self.to_screen("[Error] GraphQL response contained 'scrapeSceneURL' but it was empty.")
+                self.to_screen(f"[Debug] 'scrapeSceneURL' content: {scrape_scene_data}")
+                return None
+        except Exception as e:
+            self.to_screen(f"[Error] Error in scraping scene by URL: {str(e)}")
+            return None


### PR DESCRIPTION
This pull request significantly improves metadata accuracy and flexibility by shifting the focus of scene tagging from yt-dlp's scraped metadata to Stash's GraphQL scrapeSceneByURL query, allowing direct integration with [CommunityScrapers](https://github.com/stashapp/CommunityScrapers). This leads to more accurate and consistent metadata, especially for niche or community-supported sources. Legacy scraping is still available with the "legacy=true" variable.

### Changes introduced
- Metadata is now scraped by default from the Stash GraphQL API (user must first install relevant scrapers in Stash)
- The script identifies the corresponding scene by path and updates its metadata based on the scrape result.
- Title, date, description, cover image, tags, performers, and studio fields are all updated if available.
- Tag names are resolved to tag IDs for API compatibility.
- If a studio or performer from the scraped data doesn't exist in Stash, it is automatically created and linked.
- Added additional logging for error handling, outputs for path resolution, metadata scraping and scene updates.

### Roadmap
I would like to go further and propose the following as well in future updates:
- [ ] Default to yt-dlp (legacy) metadata if no scraper for the site is available
- [ ] Granular control over metadata scraping and creation
  - [ ] Variable for whether to add missing performers
  - [ ] Variable for whether to add missing studios
  - [ ] Variable for whether to add missing tags
  - [ ] Variable for queuing generation tasks (scene cover, previews, scrubber sprites, perceptual hashes, etc)
- [ ] Scrape data for new studios and performers automatically if available